### PR TITLE
Add default root path

### DIFF
--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/EndpointRouteBuilderExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/EndpointRouteBuilderExtensions.cs
@@ -49,7 +49,9 @@ namespace Microsoft.AspNetCore.Routing
 
             if (!(conf?.Value.EnableSwagger ?? false))
             {
-                return endpoints;
+                // If Swagger is not enabled, calls to root path are routed to ping controller to
+                // prevent AppService AlwaysOn feature to generate failed requests
+                return endpoints.MapGetRedirect("/", "/ping");
             }
 
             return endpoints.MapGetRedirect("/", "/swagger");

--- a/src/Content/Backend/NV.Templates.Backend.Web/RestApi/General/AlwaysOnController.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/RestApi/General/AlwaysOnController.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace NV.Templates.Backend.Web.RestApi.General
+{
+    /// <summary>
+    /// A controller used to respond with a 200 Status for the "Always On" configuration setting.
+    /// The "AlwaysOn" feature of Azure AppService will send requests to HTTP GET/ every 5 minutes.
+    /// </summary>
+    [Route("ping")]
+    public class AlwaysOnController : ControllerBase
+    {
+        /// <summary>
+        /// Simple action to return a 200 status response.
+        /// </summary>
+        /// <returns>Returns a 200 to avoid 404 responses.</returns>
+        [HttpGet]
+        [ApiVersionNeutral]
+        [AllowAnonymous]
+        public async Task<IActionResult> GetAlwaysOn()
+        {
+            return Ok();
+        }
+    }
+}


### PR DESCRIPTION
GitHub Issue: #
NA

## Proposed Changes
Add default root path to prevent AppService AlwaysOn feature to generate failed requests

## What is the current behavior?
AppService AlwaysOn feature calls the root path every 5 minutes to prevent the service to idle.
If there is no controller to answer, a HTTP 404 error is thrown and generate unwanted noise in logs.

## What is the new behavior?
Add a default controller that respond HTTP 200 with no payload

## Checklist
- [ ] ~~Documentation has been added/updated~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [ ] ~~Contains **NO** breaking changes~~
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~
