### PR TITLE
Add AppConfiguration setup

### DIFF
--- a/src/Content/Backend/NV.Templates.Backend.Core/Framework/Configuration/HostBuilderExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/Framework/Configuration/HostBuilderExtensions.cs
@@ -25,5 +25,23 @@ namespace Microsoft.Extensions.Hosting
 
             return hostBuilder;
         }
+
+        /// <summary>
+        /// Adds Azure App Configuration as a source of configuration when a connection string named "AppConfig" is present.
+        /// </summary>
+        public static IHostBuilder UseAzureAppConfigurationWhenPresent(this IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureAppConfiguration((context, config) =>
+            {
+                var buildConfig = config.Build();
+                var appConfigConnectionString = buildConfig.GetConnectionString("AppConfig");
+                if (!string.IsNullOrWhiteSpace(appConfigConnectionString))
+                {
+                    config.AddAzureAppConfiguration(appConfigConnectionString);
+                }
+            });
+
+            return hostBuilder;
+        }
     }
 }

--- a/src/Content/Backend/NV.Templates.Backend.Core/NV.Templates.Backend.Core.csproj
+++ b/src/Content/Backend/NV.Templates.Backend.Core/NV.Templates.Backend.Core.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.3" />


### PR DESCRIPTION
GitHub Issue: #
NA

## Proposed Changes
Add AppConfiguration setup

## What is the current behavior?
AppConfiguration is added, linked the the AppService, but not setup in the code

## What is the new behavior?
AppConfiguration is setup if the connection string exists

## Checklist
- [ ] ~~Documentation has been added/updated~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [ ] ~~Contains **NO** breaking changes~~
- [ ] Updated the Changelog
- [ ] ~~Associated with an issue~~