### PR TITLE
Add XML serialization for HTTP client

### DIFF
--- a/src/Content/Backend/NV.Templates.Backend.Core/Framework/HttpDependencies/HttpClientBuilderExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/Framework/HttpDependencies/HttpClientBuilderExtensions.cs
@@ -34,8 +34,6 @@ namespace NV.Templates.Backend.Core.Framework.HttpDependencies
             string? key = null)
             where TOptions : HttpClientOptions, new()
         {
-            builder.Services.BindOptionsToConfigurationAndValidate<TOptions>(configuration, key: key);
-
             builder.ConfigureHttpClient((sp, client) =>
             {
                 var options = sp.GetRequiredService<IOptionsMonitor<TOptions>>().CurrentValue;
@@ -91,6 +89,14 @@ namespace NV.Templates.Backend.Core.Framework.HttpDependencies
             {
                 builder = builder.AddPolicyHandler(
                     Policy.BulkheadAsync(options.MaxParallelization).AsAsyncPolicy<HttpResponseMessage>());
+            }
+
+            if (options.IgnoreCertificateValidation)
+            {
+                builder.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
+                {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+                });
             }
 
             return builder;

--- a/src/Content/Backend/NV.Templates.Backend.Core/Framework/HttpDependencies/HttpClientOptions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/Framework/HttpDependencies/HttpClientOptions.cs
@@ -44,6 +44,11 @@ namespace NV.Templates.Backend.Core.Framework.HttpDependencies
         public static readonly int DefaultMaxParallelization = 0;
 
         /// <summary>
+        /// Gets the default <see cref="Serializer"/>. (json).
+        /// </summary>
+        public static readonly string DefaultSerializer = "json";
+
+        /// <summary>
         /// Gets or sets the <see cref="HttpClient.BaseAddress"/> value.
         /// </summary>
         public Uri? BaseAddress { get; set; }
@@ -92,5 +97,15 @@ namespace NV.Templates.Backend.Core.Framework.HttpDependencies
         /// Set to 0 for unlimited parallel requests.
         /// </summary>
         public int MaxParallelization { get; set; } = DefaultMaxParallelization;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether we bypass SSL certificate validation or not.
+        /// </summary>
+        public bool IgnoreCertificateValidation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Serializer for the API (json/xml).
+        /// </summary>
+        public string Serializer { get; set; } = DefaultSerializer;
     }
 }


### PR DESCRIPTION
GitHub Issue: #
NA

## Proposed Changes
Add XML serialization for HTTP client

## What is the current behavior?
HTTP Client can only serialize/deserialize in JSON

## What is the new behavior?
HTTP Client can be used with XML serializer
We also added an option to ignore HTTPS certificate validation to allow usage of self-signed certificates

## Checklist
- [ ] ~~Documentation has been added/updated~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [ ] ~~Contains **NO** breaking changes~~
- [ ] Updated the Changelog
- [ ] ~~Associated with an issue~~