### PR TITLE
Fix operation context

### DIFF
--- a/src/Content/Backend/NV.Templates.Backend.Web.Tests/RestApi/GeneralTests.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web.Tests/RestApi/GeneralTests.cs
@@ -24,7 +24,7 @@ namespace NV.Templates.Backend.Web.Tests.RestApi
             [Get("/api/health")]
             Task<HttpResponseMessage> GetHealth();
 
-            [Get("/swagger/v1/swagger.json")]
+            [Get("/swagger/v1.0/swagger.json")]
             Task<HttpResponseMessage> GetSwaggerDocument();
 
             [Get("/attributions.txt")]

--- a/src/Content/Backend/NV.Templates.Backend.Web/Startup.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Startup.cs
@@ -70,12 +70,13 @@ namespace NV.Templates.Backend.Web
 
             app.UseRequestTracing()
                .UseExceptionHandler(ExceptionHandler.ConfigureExceptionHandling)
-               .UseResponseCaching()
-               .UseMiddleware<OperationContextMiddleware>();
+               .UseResponseCaching();
 #if Auth
             app.UseAuthentication()
                .UseAuthorization();
 #endif
+            app.UseMiddleware<OperationContextMiddleware>();
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();


### PR DESCRIPTION
GitHub Issue: #
NA

## Proposed Changes
Bug fix

## What is the current behavior?
OperationContext middleware is set too early when using authentication, causing the Principal identity to be null.

## What is the new behavior?
Move 
```
app.UseMiddleware<OperationContextMiddleware>(); 
```
after the call to 
```
app.UseAuthentication()
      .UseAuthorization();
```

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue
