### PR TITLE
fix: added global usings to fix usings reordering on template generation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,26 @@ use GitHub pull requests for this purpose. Consult [GitHub
 Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
+## Releasing a new version of the NV.Templates NuGet Package
+
+To release a new version of the NV.Templates NuGet Package, the developer needs to create a tag on a commit.
+The publish workflow pipeline will automatically kick in.
+
+To do that :
+- Go to the [releases page](https://github.com/nventive/DotNet.Backend.Template/releases/new)
+- In **Choose a tag**, type in the tag name, starting with a **v** (ex: v2.5.3), and **Create new tag: v2.5.3**
+- Choose your target branch (typically master)
+- Type in the **Release Title** (same as the tag name)
+- A quick description of the release, if necessary
+- Choose options (pre-release or latest release)
+- Click **Publish release**
+
+After, you can check the [actions](https://github.com/nventive/DotNet.Backend.Template/actions) to see that the publish pipeline is executing properly.
+
+When the pipeline completes, it can take a few minutes for the package to be available on NuGet.
+
+To make the package available locally, you will need to reinstall the packages with DotNetCLI.
+
 ## Community Guidelines
 
 This project follows [Google's Open Source Community

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Generated projects can:
 
 - Install the templates locally
 ```shell
-dotnet new install NV.Templates
+dotnet new -i NV.Templates
 ```
 
 ### Generate a Backend project

--- a/src/Content/Backend/Directory.Build.props
+++ b/src/Content/Backend/Directory.Build.props
@@ -4,7 +4,7 @@
     <Authors>CompanyName</Authors>
     <Copyright>Copyright (c) 2020, CompanyName</Copyright>
     <Product>NV.Templates.Backend</Product>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/Content/Backend/Directory.Build.props
+++ b/src/Content/Backend/Directory.Build.props
@@ -4,7 +4,7 @@
     <Authors>CompanyName</Authors>
     <Copyright>Copyright (c) 2020, CompanyName</Copyright>
     <Product>NV.Templates.Backend</Product>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/Content/Backend/NV.Templates.Backend.Console.Tests/GeneralTests.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Console.Tests/GeneralTests.cs
@@ -3,8 +3,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NV.Templates.Backend.Console.General;
-using NV.Templates.Backend.Core.General;
 using Xunit;
 
 namespace NV.Templates.Backend.Console.Tests

--- a/src/Content/Backend/NV.Templates.Backend.Console.Tests/GlobalUsings.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Console.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+﻿global using NV.Templates.Backend.Console.General;
+global using NV.Templates.Backend.Core.General;

--- a/src/Content/Backend/NV.Templates.Backend.Console/GlobalUsings.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Console/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using NV.Templates.Backend.Core.General;

--- a/src/Content/Backend/NV.Templates.Backend.Core.Tests/Framework/Continuation/ContinuationEnumerableTests.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core.Tests/Framework/Continuation/ContinuationEnumerableTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using Bogus;
 using FluentAssertions;
-using NV.Templates.Backend.Core.Framework.Continuation;
 using Xunit;
 
 namespace NV.Templates.Backend.Core.Tests.Framework.Continuation

--- a/src/Content/Backend/NV.Templates.Backend.Core.Tests/Framework/Continuation/ContinuationTokenTests.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core.Tests/Framework/Continuation/ContinuationTokenTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Bogus;
 using FluentAssertions;
-using NV.Templates.Backend.Core.Framework.Continuation;
 using Xunit;
 
 namespace NV.Templates.Backend.Core.Tests.Framework.Continuation

--- a/src/Content/Backend/NV.Templates.Backend.Core.Tests/GlobalUsings.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using NV.Templates.Backend.Core.Framework.Continuation;

--- a/src/Content/Backend/NV.Templates.Backend.Core/General/ApplicationInfo.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/General/ApplicationInfo.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NV.Templates.Backend.Core.Framework.DependencyInjection;
 
 namespace NV.Templates.Backend.Core.General
 {

--- a/src/Content/Backend/NV.Templates.Backend.Core/General/OperationContext.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/General/OperationContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Security.Principal;
 using Microsoft.Extensions.DependencyInjection;
-using NV.Templates.Backend.Core.Framework.DependencyInjection;
 
 namespace NV.Templates.Backend.Core.General
 {

--- a/src/Content/Backend/NV.Templates.Backend.Core/GlobalUsings.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Core/GlobalUsings.cs
@@ -1,0 +1,6 @@
+﻿global using NV.Templates.Backend.Core.Configuration;
+global using NV.Templates.Backend.Core.Framework.Continuation;
+global using NV.Templates.Backend.Core.Framework.DependencyInjection;
+global using NV.Templates.Backend.Core.Framework.HttpDependencies;
+global using NV.Templates.Backend.Core.Framework.Json;
+global using NV.Templates.Backend.Core.General;

--- a/src/Content/Backend/NV.Templates.Backend.Functions.Tests/GlobalUsings.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Functions.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using NV.Templates.Backend.Core.General;

--- a/src/Content/Backend/NV.Templates.Backend.Functions/GeneralFunctions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Functions/GeneralFunctions.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using NV.Templates.Backend.Core.General;
 
 namespace NV.Templates.Backend.Functions
 {

--- a/src/Content/Backend/NV.Templates.Backend.Functions/GlobalUsings.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Functions/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using NV.Templates.Backend.Core.General;

--- a/src/Content/Backend/NV.Templates.Backend.Web.Tests/GlobalUsings.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using NV.Templates.Backend.Web.RestApi.General;

--- a/src/Content/Backend/NV.Templates.Backend.Web.Tests/RestApi/GeneralTests.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web.Tests/RestApi/GeneralTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using NV.Templates.Backend.Web.RestApi.General;
 using Refit;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/EndpointRouteBuilderExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/EndpointRouteBuilderExtensions.cs
@@ -2,8 +2,6 @@
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using NV.Templates.Backend.Core.Configuration;
-using NV.Templates.Backend.Web.Framework.Middlewares;
 
 namespace Microsoft.AspNetCore.Routing
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/Middlewares/ExceptionHandler.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/Middlewares/ExceptionHandler.cs
@@ -15,8 +15,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NV.Templates.Backend.Core.Framework.Exceptions;
-using NV.Templates.Backend.Core.General;
 
 namespace NV.Templates.Backend.Web.Framework.Middlewares
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/Middlewares/OperationContextMiddleware.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/Middlewares/OperationContextMiddleware.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using NV.Templates.Backend.Core.General;
 
 namespace NV.Templates.Backend.Web.Framework.Middlewares
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/Models/ContinuationEnumerableExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/Models/ContinuationEnumerableExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using NV.Templates.Backend.Core.Framework.Continuation;
 
 namespace NV.Templates.Backend.Web.Framework.Models
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/Models/ContinuationEnumerableModel.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/Models/ContinuationEnumerableModel.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using NV.Templates.Backend.Core.Framework.Continuation;
 
 namespace NV.Templates.Backend.Web.Framework.Models
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/OpenApi/CommonHeadersOperationProcessor.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/OpenApi/CommonHeadersOperationProcessor.cs
@@ -4,8 +4,6 @@ using NJsonSchema;
 using NSwag;
 using NSwag.Generation.Processors;
 using NSwag.Generation.Processors.Contexts;
-using NV.Templates.Backend.Web.Framework.Middlewares;
-using NV.Templates.Backend.Web.Framework.Telemetry;
 
 namespace NV.Templates.Backend.Web.Framework.OpenApi
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/OpenApi/HealthChecksDocumentProcessor.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/OpenApi/HealthChecksDocumentProcessor.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using NSwag;
 using NSwag.Generation.Processors;
 using NSwag.Generation.Processors.Contexts;
-using NV.Templates.Backend.Web.Framework.Middlewares;
 
 namespace NV.Templates.Backend.Web.Framework.OpenApi
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/OpenApi/OpenApiServiceCollectionExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/OpenApi/OpenApiServiceCollectionExtensions.cs
@@ -4,9 +4,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Configuration;
-using NV.Templates.Backend.Core.General;
-using NV.Templates.Backend.Web.Framework.Middlewares;
-using NV.Templates.Backend.Web.Framework.OpenApi;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Framework/WebServiceCollectionExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Framework/WebServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using AspNetCoreRequestTracing;
 using HelpDeskId;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
-using NV.Templates.Backend.Web.Framework.Telemetry;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/GlobalUsings.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/GlobalUsings.cs
@@ -1,0 +1,10 @@
+﻿global using NV.Templates.Backend.Core.Configuration;
+global using NV.Templates.Backend.Core.Framework.Continuation;
+global using NV.Templates.Backend.Core.Framework.Exceptions;
+global using NV.Templates.Backend.Core.Framework.Json;
+global using NV.Templates.Backend.Core.General;
+global using NV.Templates.Backend.Web.Framework.Middlewares;
+global using NV.Templates.Backend.Web.Framework.Models;
+global using NV.Templates.Backend.Web.Framework.OpenApi;
+global using NV.Templates.Backend.Web.Framework.Telemetry;
+global using NV.Templates.Backend.Web.RestApi;

--- a/src/Content/Backend/NV.Templates.Backend.Web/RestApi/General/ApplicationInfoModel.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/RestApi/General/ApplicationInfoModel.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using NV.Templates.Backend.Core.General;
 
 namespace NV.Templates.Backend.Web.RestApi.General
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/RestApi/General/GeneralController.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/RestApi/General/GeneralController.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using NV.Templates.Backend.Core.General;
 
 namespace NV.Templates.Backend.Web.RestApi.General
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/RestApi/RestApiServiceCollectionExtensions.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/RestApi/RestApiServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 #if Auth
 using Microsoft.AspNetCore.Mvc.Authorization;
 #endif
-using NV.Templates.Backend.Core.Framework.Json;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/RestApi/SampleController.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/RestApi/SampleController.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
-using NV.Templates.Backend.Core.Framework.Continuation;
-using NV.Templates.Backend.Web.Framework.Models;
 
 namespace NV.Templates.Backend.Web.RestApi
 {

--- a/src/Content/Backend/NV.Templates.Backend.Web/Startup.cs
+++ b/src/Content/Backend/NV.Templates.Backend.Web/Startup.cs
@@ -7,8 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using NV.Templates.Backend.Web.Framework.Middlewares;
-using NV.Templates.Backend.Web.RestApi;
 
 [assembly: ApiController]
 [assembly: ApiConventionType(typeof(RestApiConventions))]


### PR DESCRIPTION
GitHub Issue: #37

## Proposed Changes
Adding global usings to all projects to ensure that the developer does not need to reorder the namespaces when generating a project.

- Bug fix

## What is the current behavior?
See #37 

## What is the new behavior?
No need for namespace reordering after generating a project

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [x] Associated with an issue
